### PR TITLE
Fixed aspect ratio bugs with world coordinates

### DIFF
--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -2152,6 +2152,8 @@ def setworldcoordinates(llx, lly, urx, ury):
     global xscale
     global yscale
     global _mode
+    global turtle_pos
+    global turtle_degree
     if drawing_window == None:
         raise AttributeError("Display has not been initialized yet. Call initializeTurtle() before using.")
     elif (urx-llx <= 0):
@@ -2167,7 +2169,6 @@ def setworldcoordinates(llx, lly, urx, ury):
     _mode = "world"
     turtle_pos = (_convertx(0),_converty(0))
     turtle_degree = DEFAULT_TURTLE_DEGREE
-    print(turtle_pos)
     clear()
     
 # Show a border around the graphics window. Default (no parameters) is gray. A border can be turned off by setting color='none'. 

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -1756,7 +1756,7 @@ def fillopacity(opacity=None):
 #=================================== 
 
 # Delete the turtle’s drawings from the screen, re-center the turtle and set (most) variables to the default values.
-def reset():
+def reset(win=False):
     """Resets the turtle to its initial state and clears drawing."""
 
     global is_turtle_visible
@@ -1774,6 +1774,7 @@ def reset():
     global shear_factor
     global tilt_angle
     global outline_width
+    global window_drawing
 
     is_turtle_visible = True
     pen_color = DEFAULT_PEN_COLOR
@@ -1798,7 +1799,11 @@ def reset():
         turtle_pos = (window_size[0] / 2, window_size[1] / 2)
     else:
         turtle_pos = (_convertx(0),_converty(0))
-    _updateDrawing(0)
+    if win:
+        drawing_window = None
+    else:
+        _updateDrawing(0)
+    
 
 # Clear any text or drawing on the screen
 def clear():

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -238,7 +238,8 @@ def initializeTurtle(window=None, mode=None, speed=None):
     timeout = _speedToSec(turtle_speed)
     
     if mode is None:
-        _mode = DEFAULT_MODE
+        if _mode != "world":
+            _mode = DEFAULT_MODE
     elif mode not in VALID_MODES:
         raise ValueError('Mode must be standard, world, logo, or svg')
     else:

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -13,7 +13,8 @@ It uses html capabilites of IPython library to draw svg shapes inline.
 Looks of the figures are inspired from Blockly Games / Turtle (blockly-games.appspot.com/turtle)
 
 --------
-Modified April/May 2021 by Larry Riddle
+v1.0.0 Modified April/May 2021 by Larry Riddle
+v.1.1.0 Updated July 17
 Changed some default values to match classic turtle.py package
   default background color is white, default pen color is black, default pen thickness is 1
   default mode is "standard"

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -1774,7 +1774,7 @@ def reset(win=False):
     global shear_factor
     global tilt_angle
     global outline_width
-    global window_drawing
+    global drawing_window
 
     is_turtle_visible = True
     pen_color = DEFAULT_PEN_COLOR

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -2154,14 +2154,14 @@ def window_height():
 # will be set to maintain the same aspect ratio as the axes.
 def setworldcoordinates(llx, lly, urx, ury):
     """Sets up a user defined coordinate-system.
-
+    
+    ATTENTION: Call BEFORE initializeTurtle command.
+    
     Args:
         llx: a number, x-coordinate of lower left corner of window
         lly: a number, y-coordinate of lower left corner of window
         urx: a number, x-coordinate of upper right corner of window
         ury: a number, y-coordinate of upper right corner of window
-
-    ATTENTION: Call before initializeTurtle command.
     """
 
     global xmin

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -253,7 +253,7 @@ def initializeTurtle(window=None, mode=None, speed=None):
             window_size = xsize, round((ymax-ymin)/(xmax-xmin)*xsize)
         xscale = window_size[0]/(xmax-xmin)
         yscale = window_size[1]/(ymax-ymin)               
-    if _mode != "svg":
+    elif _mode != "svg":
         xmin,ymin,xmax,ymax = -window_size[0]/2,-window_size[1]/2,window_size[0]/2,window_size[1]/2
         xscale = window_size[0]/(xmax-xmin)
         yscale = window_size[1]/(ymax-ymin)

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -252,7 +252,7 @@ def initializeTurtle(window=None, mode=None, speed=None):
             xsize = window_size[0]
             window_size = xsize, round((ymax-ymin)/(xmax-xmin)*xsize)
         xscale = window_size[0]/(xmax-xmin)
-        yscale = window_size[1]/(ymax-ymin)               
+        yscale = window_size[1]/(ymax-ymin) 
     elif _mode != "svg":
         xmin,ymin,xmax,ymax = -window_size[0]/2,-window_size[1]/2,window_size[0]/2,window_size[1]/2
         xscale = window_size[0]/(xmax-xmin)
@@ -265,6 +265,8 @@ def initializeTurtle(window=None, mode=None, speed=None):
     is_turtle_visible = DEFAULT_TURTLE_VISIBILITY
     if _mode != "world":
         turtle_pos = (window_size[0] / 2, window_size[1] / 2)
+    else:
+        turtle_pos = (_convertx(0),_converty(0))
     turtle_degree = DEFAULT_TURTLE_DEGREE if (_mode in ["standard","world"]) else (270 - DEFAULT_TURTLE_DEGREE)
     background_color = DEFAULT_BACKGROUND_COLOR
     pen_color = DEFAULT_PEN_COLOR
@@ -2177,7 +2179,7 @@ def setworldcoordinates(llx, lly, urx, ury):
     xscale = window_size[0]/(xmax-xmin)
     yscale = window_size[1]/(ymax-ymin)
     _mode = "world"
-    turtle_pos = (_convertx(0),_converty(0))
+    #turtle_pos = (_convertx(0),_converty(0))
     #turtle_degree = DEFAULT_TURTLE_DEGREE
     #clear()
     

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -1756,7 +1756,7 @@ def fillopacity(opacity=None):
 #=================================== 
 
 # Delete the turtle’s drawings from the screen, re-center the turtle and set (most) variables to the default values.
-def reset(win=False):
+def reset():
     """Resets the turtle to its initial state and clears drawing."""
 
     global is_turtle_visible
@@ -1774,7 +1774,6 @@ def reset(win=False):
     global shear_factor
     global tilt_angle
     global outline_width
-    global drawing_window
 
     is_turtle_visible = True
     pen_color = DEFAULT_PEN_COLOR
@@ -1799,10 +1798,7 @@ def reset(win=False):
         turtle_pos = (window_size[0] / 2, window_size[1] / 2)
     else:
         turtle_pos = (_convertx(0),_converty(0))
-    if win:
-        drawing_window = None
-    else:
-        _updateDrawing(0)
+    _updateDrawing(0)
     
 
 # Clear any text or drawing on the screen
@@ -2177,9 +2173,9 @@ def setworldcoordinates(llx, lly, urx, ury):
     global _mode
     global turtle_pos
     global turtle_degree
-    if drawing_window != None:
-        raise AttributeError("Display has already been initialized. Call before initializeTurtle().")
-    elif (urx-llx <= 0):
+   #if drawing_window != None:
+   #     raise AttributeError("Display has already been initialized. Call before initializeTurtle().")
+    if (urx-llx <= 0):
         raise ValueError("Lower left x-coordinate should be less than upper right x-coordinate")
     elif (ury-lly <= 0):
         raise ValueError("Lower left y-coordinate should be less than upper right y-coordinate")                      

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -2165,6 +2165,9 @@ def setworldcoordinates(llx, lly, urx, ury):
     xscale = window_size[0]/(xmax-xmin)
     yscale = window_size[1]/(ymax-ymin)
     _mode = "world"
+    turtle_pos = (_convertx(0),_converty(0))
+    turtle_degree = DEFAULT_TURTLE_DEGREE
+    clear()
     
 # Show a border around the graphics window. Default (no parameters) is gray. A border can be turned off by setting color='none'. 
 def showborder(color = None, c2 = None, c3 = None):

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -21,6 +21,7 @@ Changed some default values to match classic turtle.py package
 Added option for selecting a mode when initializing the turtle graphics
   "standard" : default direction is to the right (east) and positive angles measured counterclockwise
   "logo" : default directon is upward (north) and positive angles are measured clockwise with 0° pointing up.
+  "world" : like standard but with user-defined coordinates. Initial turtle position is (0,0).
   "svg": This is a special mode to handle how the original ColabTurtle worked. The coordinate system is the same
          as that used with SVG. The upper left corner is (0,0) with positive x direction being to the right, and the 
          positive y direction being to the bottom. Positive angles are measured clockwise with 0° pointing right.
@@ -31,7 +32,8 @@ Added additional shapes from classic turtle.py: 'classic' (the default shape), '
 Added speed=0 option that displays final image with no animation. 
   Added done function so that final image is displayed on screen when speed=0.
 Added setworldcoordinates function to allow for setting world coordinate system. This sets the mode to "world".
-  This should be done immediately after initializing the turtle window.
+  This should be done immediately *before* initializing the turtle window. The graphic window is set to maintain
+  the same aspect ratio as the axes, so angles are true.
 Added towards function to return the angle between the line from turtle position to specified position.
 Implemented begin_fill and end_fill functions from aronma/ColabTurtle_2 github. Added fillcolor function and fillrule function.
   The fillrule function can be used to specify the SVG fill_rule (nonzero or evenodd). The default is evenodd to match turtle.py behavior.
@@ -185,7 +187,7 @@ def initializeTurtle(window=None, mode=None, speed=None):
     
     Args:
         window: (optional) the (width,height) in pixels
-        mode: (optional) one of "standard, "logo", or "svg"
+        mode: (optional) one of "standard, "logo", "world", or "svg"
         speed: (optional) integer in range 0..13
     
     The defaults are (800,600), "standard", and 5.
@@ -2144,7 +2146,8 @@ def window_height():
     return window_size[1]
 
 # Set up user-defined coordinate system using lower left and upper right corners.
-# ATTENTION: in user-defined coordinate systems angles may appear distorted.
+# Should be called immediately *before* initializeTurtle. The graphic window size
+# will be set to maintain the same aspect ratio as the axes.
 def setworldcoordinates(llx, lly, urx, ury):
     """Sets up a user defined coordinate-system.
 
@@ -2154,8 +2157,7 @@ def setworldcoordinates(llx, lly, urx, ury):
         urx: a number, x-coordinate of upper right corner of window
         ury: a number, y-coordinate of upper right corner of window
 
-    ATTENTION: In user-defined coordinate systems, angles may appear
-    distorted.
+    ATTENTION: Call before initializeTurtle command.
     """
 
     global xmin
@@ -2167,9 +2169,9 @@ def setworldcoordinates(llx, lly, urx, ury):
     global _mode
     global turtle_pos
     global turtle_degree
-    #if drawing_window == None:
-        #raise AttributeError("Display has not been initialized yet. Call initializeTurtle() before using.")
-    if (urx-llx <= 0):
+    if drawing_window != None:
+        raise AttributeError("Display has already been initialized. Call before initializeTurtle().")
+    elif (urx-llx <= 0):
         raise ValueError("Lower left x-coordinate should be less than upper right x-coordinate")
     elif (ury-lly <= 0):
         raise ValueError("Lower left y-coordinate should be less than upper right y-coordinate")                      
@@ -2180,9 +2182,6 @@ def setworldcoordinates(llx, lly, urx, ury):
     xscale = window_size[0]/(xmax-xmin)
     yscale = window_size[1]/(ymax-ymin)
     _mode = "world"
-    #turtle_pos = (_convertx(0),_converty(0))
-    #turtle_degree = DEFAULT_TURTLE_DEGREE
-    #clear()
     
 # Show a border around the graphics window. Default (no parameters) is gray. A border can be turned off by setting color='none'. 
 def showborder(color = None, c2 = None, c3 = None):

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -244,6 +244,15 @@ def initializeTurtle(window=None, mode=None, speed=None):
     else:
         _mode = mode
     
+    if _mode == "world":
+        if ymax-ymin > xmax-xmin:
+            ysize = window_size[1]
+            window_size = round((xmax-xmin)/(ymax-ymin)*ysize),ysize
+        else:
+            xsize = window_size[0]
+            window_size = xsize, round((ymax-ymin)/(xmax-xmin)*xsize)
+        xscale = window_size[0]/(xmax-xmin)
+        yscale = window_size[1]/(ymax-ymin)               
     if _mode != "svg":
         xmin,ymin,xmax,ymax = -window_size[0]/2,-window_size[1]/2,window_size[0]/2,window_size[1]/2
         xscale = window_size[0]/(xmax-xmin)
@@ -254,7 +263,8 @@ def initializeTurtle(window=None, mode=None, speed=None):
         yscale = -1
        
     is_turtle_visible = DEFAULT_TURTLE_VISIBILITY
-    turtle_pos = (window_size[0] / 2, window_size[1] / 2)
+    if _mode != "world":
+        turtle_pos = (window_size[0] / 2, window_size[1] / 2)
     turtle_degree = DEFAULT_TURTLE_DEGREE if (_mode in ["standard","world"]) else (270 - DEFAULT_TURTLE_DEGREE)
     background_color = DEFAULT_BACKGROUND_COLOR
     pen_color = DEFAULT_PEN_COLOR
@@ -2155,7 +2165,7 @@ def setworldcoordinates(llx, lly, urx, ury):
     global turtle_pos
     global turtle_degree
     if drawing_window == None:
-        raise AttributeError("Display has not been initialized yet. Call initializeTurtle() before using.")
+        #raise AttributeError("Display has not been initialized yet. Call initializeTurtle() before using.")
     elif (urx-llx <= 0):
         raise ValueError("Lower left x-coordinate should be less than upper right x-coordinate")
     elif (ury-lly <= 0):

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -1794,7 +1794,10 @@ def reset():
     stampnum = 0
     stamplist = []
     turtle_degree = DEFAULT_TURTLE_DEGREE if (_mode in ["standard","world"]) else (270 - DEFAULT_TURTLE_DEGREE)
-    turtle_pos = (window_size[0] / 2, window_size[1] / 2)
+    if _mode != "world":
+        turtle_pos = (window_size[0] / 2, window_size[1] / 2)
+    else:
+        turtle_pos = (_convertx(0),_converty(0))
     _updateDrawing(0)
 
 # Clear any text or drawing on the screen

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -2178,8 +2178,8 @@ def setworldcoordinates(llx, lly, urx, ury):
     yscale = window_size[1]/(ymax-ymin)
     _mode = "world"
     turtle_pos = (_convertx(0),_converty(0))
-    turtle_degree = DEFAULT_TURTLE_DEGREE
-    clear()
+    #turtle_degree = DEFAULT_TURTLE_DEGREE
+    #clear()
     
 # Show a border around the graphics window. Default (no parameters) is gray. A border can be turned off by setting color='none'. 
 def showborder(color = None, c2 = None, c3 = None):

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -2167,6 +2167,7 @@ def setworldcoordinates(llx, lly, urx, ury):
     _mode = "world"
     turtle_pos = (_convertx(0),_converty(0))
     turtle_degree = DEFAULT_TURTLE_DEGREE
+    print(turtle_pos)
     clear()
     
 # Show a border around the graphics window. Default (no parameters) is gray. A border can be turned off by setting color='none'. 

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -2164,9 +2164,9 @@ def setworldcoordinates(llx, lly, urx, ury):
     global _mode
     global turtle_pos
     global turtle_degree
-    if drawing_window == None:
+    #if drawing_window == None:
         #raise AttributeError("Display has not been initialized yet. Call initializeTurtle() before using.")
-    elif (urx-llx <= 0):
+    if (urx-llx <= 0):
         raise ValueError("Lower left x-coordinate should be less than upper right x-coordinate")
     elif (ury-lly <= 0):
         raise ValueError("Lower left y-coordinate should be less than upper right y-coordinate")                      

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -237,13 +237,13 @@ def initializeTurtle(window=None, mode=None, speed=None):
         turtle_speed = speed
     timeout = _speedToSec(turtle_speed)
     
-    if _mode == "world":
-    elif mode is None:
-         _mode = DEFAULT_MODE
-    elif mode not in VALID_MODES:
-        raise ValueError('Mode must be standard, world, logo, or svg')
-    else:
-        _mode = mode
+    if _mode != "world":   
+        if mode is None:
+            _mode = DEFAULT_MODE
+        elif mode not in VALID_MODES:
+            raise ValueError('Mode must be standard, world, logo, or svg')
+        else:
+            _mode = mode
     
     if _mode == "world":
         if ymax-ymin > xmax-xmin:

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -237,9 +237,9 @@ def initializeTurtle(window=None, mode=None, speed=None):
         turtle_speed = speed
     timeout = _speedToSec(turtle_speed)
     
-    if mode is None:
-        if _mode != "world":
-            _mode = DEFAULT_MODE
+    if _mode == "world":
+    elif mode is None:
+         _mode = DEFAULT_MODE
     elif mode not in VALID_MODES:
         raise ValueError('Mode must be standard, world, logo, or svg')
     else:


### PR DESCRIPTION
Drawing was not correct when aspect ratio of window was not the same as the aspect ratio of axes.
setworldcoordinates must now be called **before** initializeTurtle. This allows initializeTurtle to adjust either the width or the height of the drawing window to match the aspect ratio of the axes.