### PR TITLE
modify fill to allow for multiple border colors

### DIFF
--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -1794,7 +1794,7 @@ def end_fill():
             bddry = 'none'
         else:
             bddry = 'none'
-        svg_fill_string += """" stroke-linecap="round" stroke-width=1 fill="{fillcolor}" />""".format(
+        svg_fill_string += """" stroke-linecap="round" style="stroke-width=0" fill="{fillcolor}" />""".format(
          #       pencolor=bddry,
        #         penwidth=pen_width,
                 fillcolor=fill_color)

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -1798,7 +1798,7 @@ def end_fill():
        #         pencolor=bddry,
        #         penwidth=pen_width,
        #         fillcolor=fill_color)
-        svg_fill_string += """" stroke-linecap="round" style="stroke:{pencolor};stroke-width:{penwidth}" fill="{fillcolor}" />""".format(
+        svg_fill_string += """"  fill="{fillcolor}" />""".format(
                 #pencolor=bddry,
                 #penwidth=pen_width,
                 fillcolor=fill_color)

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -1794,7 +1794,7 @@ def end_fill():
             bddry = 'none'
         else:
             bddry = 'none'
-        svg_fill_string += """" stroke-linecap="round" style="stroke-width:{0}" fill="{fillcolor}" />""".format(
+        svg_fill_string += """" stroke-linecap="round" stroke-width=0 fill="{fillcolor}" />""".format(
          #       pencolor=bddry,
        #         penwidth=pen_width,
                 fillcolor=fill_color)

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -1794,7 +1794,7 @@ def end_fill():
             bddry = 'none'
         else:
             bddry = 'none'
-        svg_fill_string += """" stroke-linecap="round" stroke-width=0 fill="{fillcolor}" />""".format(
+        svg_fill_string += """" stroke-linecap="round" stroke-width=1 fill="{fillcolor}" />""".format(
          #       pencolor=bddry,
        #         penwidth=pen_width,
                 fillcolor=fill_color)

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -1794,9 +1794,13 @@ def end_fill():
             bddry = pen_color
         else:
             bddry = 'none'
+       # svg_fill_string += """" stroke-linecap="round" style="stroke:{pencolor};stroke-width:{penwidth}" fill="{fillcolor}" />""".format(
+       #         pencolor=bddry,
+       #         penwidth=pen_width,
+       #         fillcolor=fill_color)
         svg_fill_string += """" stroke-linecap="round" style="stroke:{pencolor};stroke-width:{penwidth}" fill="{fillcolor}" />""".format(
-                pencolor=bddry,
-                penwidth=pen_width,
+                #pencolor=bddry,
+                #penwidth=pen_width,
                 fillcolor=fill_color)
         svg_lines_string = svg_lines_string_orig + svg_fill_string
         _updateDrawing(0)

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -1739,8 +1739,6 @@ def filling():
 
 # Initialize the string for the svg path of the filled shape.
 # Modified from aronma/ColabTurtle_2 github repo
-# The current svg_lines_string is stored to be used when the fill is finished because the svg_fill_string will include
-# the svg code for the path generated between the begin and end fill commands.
 # When calling begin_fill, a value for the fill_rule can be given that will apply only to that fill.
 def begin_fill(rule=None, opacity=None):
     """Called just before drawing a shape to be filled.
@@ -1758,7 +1756,6 @@ def begin_fill(rule=None, opacity=None):
     """
 
     global is_filling
-    global svg_lines_string_orig
     global svg_fill_string
     if rule is None:
          rule = fill_rule
@@ -1770,7 +1767,6 @@ def begin_fill(rule=None, opacity=None):
     if (opacity < 0) or (opacity > 1):
         raise ValueError("The fill_opacity should be between 0 and 1.")
     if not is_filling:
-        svg_lines_string_orig = svg_lines_string
         svg_fill_string = """<path fill-rule="{rule}" fill-opacity="{opacity}" d="M {x1} {y1} """.format(
                 x1=turtle_pos[0],
                 y1=turtle_pos[1],
@@ -1780,8 +1776,6 @@ def begin_fill(rule=None, opacity=None):
     
 # Terminate the string for the svg path of the filled shape
 # Modified from aronma/ColabTurtle_2 github repo
-# The original svg_lines_string was previously stored to be used when the fill is finished because the svg_fill_string will include
-# the svg code for the path generated between the begin and end fill commands. 
 def end_fill():
     """Fill the shape drawn after the call begin_fill()."""
 
@@ -1790,19 +1784,8 @@ def end_fill():
     global svg_fill_string
     if is_filling:
         is_filling = False
-        if is_pen_down:
-            bddry = 'none'
-        else:
-            bddry = 'none'
         svg_fill_string += """" stroke-linecap="round" style="stroke-width=0" fill="{fillcolor}" />""".format(
-         #       pencolor=bddry,
-       #         penwidth=pen_width,
                 fillcolor=fill_color)
-        #svg_fill_string += """"  fill="{fillcolor}" />""".format(
-        #        #pencolor=bddry,
-                #penwidth=pen_width,
-         #       fillcolor=fill_color)
-        #svg_lines_string = svg_lines_string_orig + svg_fill_string
         svg_lines_string = svg_fill_string + svg_lines_string
         _updateDrawing(0)
      

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -1791,18 +1791,19 @@ def end_fill():
     if is_filling:
         is_filling = False
         if is_pen_down:
-            bddry = pen_color
+            bddry = 'none'
         else:
             bddry = 'none'
-       # svg_fill_string += """" stroke-linecap="round" style="stroke:{pencolor};stroke-width:{penwidth}" fill="{fillcolor}" />""".format(
-       #         pencolor=bddry,
+        svg_fill_string += """" stroke-linecap="round" style="stroke-width:{0}" fill="{fillcolor}" />""".format(
+         #       pencolor=bddry,
        #         penwidth=pen_width,
-       #         fillcolor=fill_color)
-        svg_fill_string += """"  fill="{fillcolor}" />""".format(
-                #pencolor=bddry,
-                #penwidth=pen_width,
                 fillcolor=fill_color)
-        svg_lines_string = svg_lines_string_orig + svg_fill_string
+        #svg_fill_string += """"  fill="{fillcolor}" />""".format(
+        #        #pencolor=bddry,
+                #penwidth=pen_width,
+         #       fillcolor=fill_color)
+        #svg_lines_string = svg_lines_string_orig + svg_fill_string
+        svg_lines_string = svg_fill_string + svg_lines_string
         _updateDrawing(0)
      
 # Allow user to set the svg fill-rule. Options are only 'nonzero' or 'evenodd'. If no argument, return current fill-rule.


### PR DESCRIPTION
Fixed a flaw where end_fill could overwrite pencolor choices for the border of what was being filled.