### PR TITLE
Revert to previous version of fill

### DIFF
--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -1785,8 +1785,10 @@ def end_fill():
     global svg_fill_string
     if is_filling:
         is_filling = False
-        svg_fill_string += """" stroke-linecap="round" style="stroke-width=0" fill="{fillcolor}" />""".format(
-                fillcolor=fill_color)
+        svg_fill_string += """" stroke-linecap="round" style="stroke={pen},stroke-width={size}" fill="{fillcolor}" />""".format(
+                fillcolor=fill_color,
+                pen = "none",
+                size = pen_width)
         svg_lines_string += svg_fill_string 
         _updateDrawing(0)
      

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -1740,6 +1740,8 @@ def filling():
 
 # Initialize the string for the svg path of the filled shape.
 # Modified from aronma/ColabTurtle_2 github repo
+# The current svg_lines_string is stored to be used when the fill is finished because the svg_fill_string will include
+# the svg code for the path generated between the begin and end fill commands.
 # When calling begin_fill, a value for the fill_rule can be given that will apply only to that fill.
 def begin_fill(rule=None, opacity=None):
     """Called just before drawing a shape to be filled.
@@ -1757,6 +1759,7 @@ def begin_fill(rule=None, opacity=None):
     """
 
     global is_filling
+    global svg_lines_string_orig
     global svg_fill_string
     if rule is None:
          rule = fill_rule
@@ -1768,6 +1771,7 @@ def begin_fill(rule=None, opacity=None):
     if (opacity < 0) or (opacity > 1):
         raise ValueError("The fill_opacity should be between 0 and 1.")
     if not is_filling:
+        svg_lines_string_orig = svg_lines_string
         svg_fill_string = """<path fill-rule="{rule}" fill-opacity="{opacity}" d="M {x1} {y1} """.format(
                 x1=turtle_pos[0],
                 y1=turtle_pos[1],
@@ -1777,19 +1781,27 @@ def begin_fill(rule=None, opacity=None):
     
 # Terminate the string for the svg path of the filled shape
 # Modified from aronma/ColabTurtle_2 github repo
+# The original svg_lines_string was previously stored to be used when the fill is finished because the svg_fill_string will include
+# the svg code for the path generated between the begin and end fill commands.
+# the svg code for the path generated between the begin and end fill commands.
 def end_fill():
     """Fill the shape drawn after the call begin_fill()."""
 
     global is_filling   
     global svg_lines_string
+    global svg_lines_string_orig
     global svg_fill_string
     if is_filling:
         is_filling = False
+        if is_pen_down:
+            bddry = pen_color
+        else:
+            bddry = 'none'
         svg_fill_string += """" stroke-linecap="round" style="stroke={pen},stroke-width={size}" fill="{fillcolor}" />""".format(
                 fillcolor=fill_color,
-                pen = "none",
+                pen = bddry,
                 size = pen_width)
-        svg_lines_string += svg_fill_string 
+        svg_lines_string = svg_lines_string_orig + svg_fill_string 
         _updateDrawing(0)
      
 # Allow user to set the svg fill-rule. Options are only 'nonzero' or 'evenodd'. If no argument, return current fill-rule.

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -1787,7 +1787,7 @@ def end_fill():
         is_filling = False
         svg_fill_string += """" stroke-linecap="round" style="stroke-width=0" fill="{fillcolor}" />""".format(
                 fillcolor=fill_color)
-        svg_lines_string = svg_fill_string + svg_lines_string
+        svg_lines_string += svg_fill_string 
         _updateDrawing(0)
      
 # Allow user to set the svg fill-rule. Options are only 'nonzero' or 'evenodd'. If no argument, return current fill-rule.

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -1797,7 +1797,7 @@ def end_fill():
             bddry = pen_color
         else:
             bddry = 'none'
-        svg_fill_string += """" stroke-linecap="round" style="stroke:{pen};stroke-width={size}" fill="{fillcolor}" />""".format(
+        svg_fill_string += """" stroke-linecap="round" style="stroke:{pen};stroke-width:{size}" fill="{fillcolor}" />""".format(
                 fillcolor=fill_color,
                 pen = bddry,
                 size = pen_width)

--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -1797,7 +1797,7 @@ def end_fill():
             bddry = pen_color
         else:
             bddry = 'none'
-        svg_fill_string += """" stroke-linecap="round" style="stroke={pen},stroke-width={size}" fill="{fillcolor}" />""".format(
+        svg_fill_string += """" stroke-linecap="round" style="stroke:{pen};stroke-width={size}" fill="{fillcolor}" />""".format(
                 fillcolor=fill_color,
                 pen = bddry,
                 size = pen_width)

--- a/Documentation.md
+++ b/Documentation.md
@@ -153,7 +153,7 @@ Works the same as `pencolor` for the fillcolor.
 
 Because the fill is controlled by svg rules, the result may differ from classic turtle fill. The fill-rule and fill-opacity can be set as arguments to the begin_fill() function and will apply only to objects filled before the end_fill is called. There are two possible arguments to specify the SVG fill-rule: 'nonzero' and 'evenodd'. The default is 'evenodd' to match the fill behavior in classic turtle.py. See https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-rule for details.
 
-Note: end_fill() will use the current pen color and current pen width for the boundary of the area being filled. If you want to change the pen color or width during the fill, you will need to do a separate begin_fill, end_fill pair for each separate color and/or width.
+Note: end_fill() will use the current pen color and current pen width for the boundary of the area being filled. If you want to change the pen color or width during the fill, you can do a separate begin_fill, end_fill pair for each color and/or width. Or you can execute the code twice, the first time with the fill, then a second time without the fill. It would be necessary to save the turtle position and heading before starting the first pass so that you can return to that position (using jumpto) and heading to repeat the code for the second pass. 
 
 #### Pen Control - More Drawing Control
 

--- a/Documentation.md
+++ b/Documentation.md
@@ -1,3 +1,5 @@
+# Documentation for ColabTurtlePlus
+
 Installation
 ----
 Create an empty code cell and type:
@@ -150,6 +152,8 @@ Works the same as `pencolor` for the fillcolor.
 `fillopacity(opacity)` -> Sets the global fill-opacity used by SVG to fill an object. The default is 1. The `begin_fill()` function can take an argument between 0 and 1 to set the fill_opacity just for that fill.
 
 Because the fill is controlled by svg rules, the result may differ from classic turtle fill. The fill-rule and fill-opacity can be set as arguments to the begin_fill() function and will apply only to objects filled before the end_fill is called. There are two possible arguments to specify the SVG fill-rule: 'nonzero' and 'evenodd'. The default is 'evenodd' to match the fill behavior in classic turtle.py. See https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-rule for details.
+
+Note: end_fill() will use the current pen color and current pen width for the boundary of the area being filled. If you want to change the pen color or width during the fill, you will need to do a separate begin_fill, end_fill pair for each separate color and/or width.
 
 #### Pen Control - More Drawing Control
 


### PR DESCRIPTION
A change to how filling was done created unexpected issues. So this version returns to the way fill had first been done. If the pen color or width changes between the begin_fill and the end_fill commands, only the last pen color or width will be used. To get around this, either use multiple begin/end fill commands for each time the pen color or width changes, or do the drawing twice, the first time with the fill, then a second time without it.