### PR TITLE
Fix regex pattern for RGB color validation

### DIFF
--- a/ColabTurtlePlus/Turtle.py
+++ b/ColabTurtlePlus/Turtle.py
@@ -741,7 +741,7 @@ class _Screen:
             return True
         if re.search("^#(?:[0-9a-fA-F]{3}){1,2}$", color): # 3 or 6 digit hex color code
             return True
-        if re.search("rgb\(\s*(?:(?:\d{1,2}|1\d\d|2(?:[0-4]\d|5[0-5]))\s*,?){3}\)$", color): # rgb color code
+        if re.search(r"rgb\(\s*(?:(?:\d{1,2}|1\d\d|2(?:[0-4]\d|5[0-5]))\s*,?){3}\)$", color): # rgb color code
             return True
         return False
 


### PR DESCRIPTION
Fix Python 3.13+ SyntaxWarning by using raw strings in regular expressions. Warning shows up in JupyterLite but not in Colab.